### PR TITLE
Add "optional" flag to ConfZFileSource

### DIFF
--- a/confz/confz_source.py
+++ b/confz/confz_source.py
@@ -40,6 +40,9 @@ class ConfZFileSource(ConfZSource):
     file ending."""
     encoding: str = "utf-8"
     """The encoding of the file. Default is UTF-8."""
+    optional: bool = False
+    """True if this config file is only optional. If set to True no error is thrown
+    when the file was not found."""
 
 
 @dataclass

--- a/confz/loaders/file_loader.py
+++ b/confz/loaders/file_loader.py
@@ -83,7 +83,11 @@ class FileLoader(Loader):
 
     @classmethod
     def _read_file(
-        cls, file_path: Path, file_format: FileFormat, file_encoding: str, optional: bool
+        cls,
+        file_path: Path,
+        file_format: FileFormat,
+        file_encoding: str,
+        optional: bool,
     ) -> dict:
         try:
             with file_path.open(encoding=file_encoding) as f:
@@ -95,11 +99,11 @@ class FileLoader(Loader):
                     file_content = toml.load(f)
         except OSError as e:
             if optional:
-                return dict()
-            else:
-                raise ConfZFileException(
-                    f"Could not open config file '{file_path}'."
-                ) from e
+                return {}
+
+            raise ConfZFileException(
+                f"Could not open config file '{file_path}'."
+            ) from e
 
         return file_content
 
@@ -107,5 +111,7 @@ class FileLoader(Loader):
     def populate_config(cls, config: dict, confz_source: ConfZFileSource):
         file_path = cls._get_filename(confz_source)
         file_format = cls._get_format(file_path, confz_source.format)
-        file_content = cls._read_file(file_path, file_format, confz_source.encoding, confz_source.optional)
+        file_content = cls._read_file(
+            file_path, file_format, confz_source.encoding, confz_source.optional
+        )
         cls.update_dict_recursively(config, file_content)

--- a/confz/loaders/file_loader.py
+++ b/confz/loaders/file_loader.py
@@ -83,7 +83,7 @@ class FileLoader(Loader):
 
     @classmethod
     def _read_file(
-        cls, file_path: Path, file_format: FileFormat, file_encoding: str
+        cls, file_path: Path, file_format: FileFormat, file_encoding: str, optional: bool
     ) -> dict:
         try:
             with file_path.open(encoding=file_encoding) as f:
@@ -94,9 +94,12 @@ class FileLoader(Loader):
                 elif file_format == FileFormat.TOML:
                     file_content = toml.load(f)
         except OSError as e:
-            raise ConfZFileException(
-                f"Could not open config file '{file_path}'."
-            ) from e
+            if optional:
+                return dict()
+            else:
+                raise ConfZFileException(
+                    f"Could not open config file '{file_path}'."
+                ) from e
 
         return file_content
 
@@ -104,5 +107,5 @@ class FileLoader(Loader):
     def populate_config(cls, config: dict, confz_source: ConfZFileSource):
         file_path = cls._get_filename(confz_source)
         file_format = cls._get_format(file_path, confz_source.format)
-        file_content = cls._read_file(file_path, file_format, confz_source.encoding)
+        file_content = cls._read_file(file_path, file_format, confz_source.encoding, confz_source.optional)
         cls.update_dict_recursively(config, file_content)

--- a/tests/assets/config_2.yml
+++ b/tests/assets/config_2.yml
@@ -1,0 +1,3 @@
+inner:
+  attr1: 4 🎉
+attr2: 10

--- a/tests/loaders/test_file_loader.py
+++ b/tests/loaders/test_file_loader.py
@@ -44,8 +44,10 @@ def test_yaml_file():
 
 def test_multiple_yaml_files_both_available():
     config = OuterConfig(
-        config_sources=[ConfZFileSource(file=ASSET_FOLDER / "config.yml"),
-                        ConfZFileSource(file=ASSET_FOLDER / "config_2.yml")]
+        config_sources=[
+            ConfZFileSource(file=ASSET_FOLDER / "config.yml"),
+            ConfZFileSource(file=ASSET_FOLDER / "config_2.yml"),
+        ]
     )
     assert config.inner.attr1 == "4 🎉"
     assert config.attr2 == "10"
@@ -53,8 +55,12 @@ def test_multiple_yaml_files_both_available():
 
 def test_multiple_yaml_files_one_is_optional_and_unavailable():
     config = OuterConfig(
-        config_sources=[ConfZFileSource(file=ASSET_FOLDER / "config.yml"),
-                        ConfZFileSource(file=ASSET_FOLDER / "config_not_existing.yml", optional=True)]
+        config_sources=[
+            ConfZFileSource(file=ASSET_FOLDER / "config.yml"),
+            ConfZFileSource(
+                file=ASSET_FOLDER / "config_not_existing.yml", optional=True
+            ),
+        ]
     )
     assert config.inner.attr1 == "1 🎉"
     assert config.attr2 == "2"

--- a/tests/loaders/test_file_loader.py
+++ b/tests/loaders/test_file_loader.py
@@ -42,6 +42,24 @@ def test_yaml_file():
     assert config.attr2 == "2"
 
 
+def test_multiple_yaml_files_both_available():
+    config = OuterConfig(
+        config_sources=[ConfZFileSource(file=ASSET_FOLDER / "config.yml"),
+                        ConfZFileSource(file=ASSET_FOLDER / "config_2.yml")]
+    )
+    assert config.inner.attr1 == "4 🎉"
+    assert config.attr2 == "10"
+
+
+def test_multiple_yaml_files_one_is_optional_and_unavailable():
+    config = OuterConfig(
+        config_sources=[ConfZFileSource(file=ASSET_FOLDER / "config.yml"),
+                        ConfZFileSource(file=ASSET_FOLDER / "config_not_existing.yml", optional=True)]
+    )
+    assert config.inner.attr1 == "1 🎉"
+    assert config.attr2 == "2"
+
+
 def test_toml_file():
     config = SecondOuterConfig(
         config_sources=ConfZFileSource(file=ASSET_FOLDER / "config.toml")


### PR DESCRIPTION
The "optional" flag makes it possible to avoid an exception when a file is not available.

This mechanism can be used to implement chains of config files that are optional.