### PR TITLE
Extend "optional" flag for ConfZFileSource to ignore more exceptions

### DIFF
--- a/confz/confz_source.py
+++ b/confz/confz_source.py
@@ -42,8 +42,8 @@ class ConfZFileSource(ConfZSource):
     """The encoding of the file. Default is UTF-8."""
     optional: bool = False
     """True if this config file is only optional. If set to True no error is
-    thrown when the file was not found, when the environment variable or the command
-    line argument was not set, or when the file format is invalid."""
+    thrown when the file was not found or when the environment variable or the
+    command line argument were not set."""
 
 
 @dataclass

--- a/confz/confz_source.py
+++ b/confz/confz_source.py
@@ -41,8 +41,9 @@ class ConfZFileSource(ConfZSource):
     encoding: str = "utf-8"
     """The encoding of the file. Default is UTF-8."""
     optional: bool = False
-    """True if this config file is only optional. If set to True no error is thrown
-    when the file was not found."""
+    """True if this config file is only optional. If set to True no error is
+    thrown when the file was not found, when the environment variable or the command
+    line argument was not set, or when the file format is invalid."""
 
 
 @dataclass

--- a/confz/loaders/file_loader.py
+++ b/confz/loaders/file_loader.py
@@ -87,7 +87,6 @@ class FileLoader(Loader):
         file_path: Path,
         file_format: FileFormat,
         file_encoding: str,
-        optional: bool,
     ) -> dict:
         try:
             with file_path.open(encoding=file_encoding) as f:
@@ -98,9 +97,6 @@ class FileLoader(Loader):
                 elif file_format == FileFormat.TOML:
                     file_content = toml.load(f)
         except OSError as e:
-            if optional:
-                return {}
-
             raise ConfZFileException(
                 f"Could not open config file '{file_path}'."
             ) from e
@@ -109,9 +105,12 @@ class FileLoader(Loader):
 
     @classmethod
     def populate_config(cls, config: dict, confz_source: ConfZFileSource):
-        file_path = cls._get_filename(confz_source)
-        file_format = cls._get_format(file_path, confz_source.format)
-        file_content = cls._read_file(
-            file_path, file_format, confz_source.encoding, confz_source.optional
-        )
+        try:
+            file_path = cls._get_filename(confz_source)
+            file_format = cls._get_format(file_path, confz_source.format)
+            file_content = cls._read_file(file_path, file_format, confz_source.encoding)
+        except ConfZFileException as e:
+            if confz_source.optional:
+                return
+            raise e
         cls.update_dict_recursively(config, file_content)

--- a/confz/loaders/file_loader.py
+++ b/confz/loaders/file_loader.py
@@ -107,7 +107,12 @@ class FileLoader(Loader):
     def populate_config(cls, config: dict, confz_source: ConfZFileSource):
         try:
             file_path = cls._get_filename(confz_source)
-            file_format = cls._get_format(file_path, confz_source.format)
+        except ConfZFileException as e:
+            if confz_source.optional:
+                return
+            raise e
+        file_format = cls._get_format(file_path, confz_source.format)
+        try:
             file_content = cls._read_file(file_path, file_format, confz_source.encoding)
         except ConfZFileException as e:
             if confz_source.optional:

--- a/tests/loaders/test_file_loader.py
+++ b/tests/loaders/test_file_loader.py
@@ -170,3 +170,15 @@ def test_from_cl_arg_name(monkeypatch):
     )
     assert config.inner.attr1 == "1 🎉"
     assert config.attr2 == "2"
+
+
+def test_from_cl_arg_optional():
+    # if not set, should load the config file without errors
+    config = OuterConfig(
+        config_sources=[
+            ConfZFileSource(file_from_cl="--my_config_file", optional=True),
+            ConfZFileSource(file=ASSET_FOLDER / "config.yml"),
+        ]
+    )
+    assert config.inner.attr1 == "1 🎉"
+    assert config.attr2 == "2"


### PR DESCRIPTION
See PR #50 and issue #52.

`optional` now makes it possible to ignore if a command line argument is not set (through `file_from_cl`) or if an environment variable is not present (`file_from_env`).
