### PR TITLE
Added the possibility to provide configuration file data directly as bytes string.

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,7 +49,7 @@ class APIConfig(ConfZ):
     port: int
     db: DBConfig
 
-    CONFIG_SOURCES = ConfZFileSource(file=Path('/path/to/config.yml'))
+    CONFIG_SOURCES = ConfZFileSource(file='/path/to/config.yml')
 ```
 
 Thanks to [pydantic](https://pydantic-docs.helpmanual.io/), you can use a wide variety of
@@ -93,7 +93,7 @@ from confz import ConfZ, ConfZFileSource
 class MyConfig(ConfZ):
     ...
     CONFIG_SOURCES = ConfZFileSource(
-        folder=Path('/path/to/config/folder'),
+        folder='/path/to/config/folder',
         file_from_env='ENVIRONMENT'
     )
 ```
@@ -110,7 +110,7 @@ from confz import ConfZ, ConfZEnvSource, ConfZCLArgSource
 class MyConfig(ConfZ):
     ...
     CONFIG_SOURCES = [
-        ConfZEnvSource(allow_all=True, file=Path(".env.local")),
+        ConfZEnvSource(allow_all=True, file=".env.local"),
         ConfZCLArgSource(prefix='conf_')
     ]
 ```
@@ -134,7 +134,7 @@ class MyConfig(ConfZ):
     number: int
     text: str
 
-config1 = MyConfig(config_sources=ConfZFileSource(file=Path('/path/to/config.yml')))
+config1 = MyConfig(config_sources=ConfZFileSource(file='/path/to/config.yml'))
 config2 = MyConfig(config_sources=ConfZEnvSource(prefix='CONF_', allow=['text']), number=1)
 config3 = MyConfig(number=1, text='hello world')
 ```
@@ -157,7 +157,7 @@ from confz import ConfZ, ConfZFileSource, ConfZDataSource
 
 class MyConfig(ConfZ):
     number: int
-    CONFIG_SOURCES = ConfZFileSource(file=Path('/path/to/config.yml'))
+    CONFIG_SOURCES = ConfZFileSource(file="/path/to/config.yml")
 
 print(MyConfig().number)                            # will print the value from the config-file
 

--- a/confz/confz_source.py
+++ b/confz/confz_source.py
@@ -1,5 +1,6 @@
 from dataclasses import dataclass
 from enum import Enum
+from os import PathLike
 from pathlib import Path
 from typing import Optional, Union, List, Dict, Any
 
@@ -24,8 +25,9 @@ class FileFormat(Enum):
 class ConfZFileSource(ConfZSource):
     """Source config for files."""
 
-    file: Optional[Path] = None
-    """Specify a config file directly by a path."""
+    file: Union[PathLike, str, bytes, None] = None
+    """Specify a config file directly by a path or by providing its content as 
+    bytes-string."""
     file_from_env: Optional[str] = None
     """Alternatively, use this environment variable to get the file."""
     file_from_cl: Optional[Union[int, str]] = None

--- a/confz/confz_source.py
+++ b/confz/confz_source.py
@@ -26,7 +26,7 @@ class ConfZFileSource(ConfZSource):
     """Source config for files."""
 
     file: Union[PathLike, str, bytes, None] = None
-    """Specify a config file directly by a path or by providing its content as 
+    """Specify a config file directly by a path or by providing its content as
     bytes-string."""
     file_from_env: Optional[str] = None
     """Alternatively, use this environment variable to get the file."""

--- a/confz/confz_source.py
+++ b/confz/confz_source.py
@@ -35,7 +35,7 @@ class ConfZFileSource(ConfZSource):
     be a specific position (integer, e.g. `1`) or after a specific option (string,
     e.g. `\\-\\-config-file`). In the latter case, the file name must follow after
     whitespace, an equal sign between argument and value is not supported right now."""
-    folder: Optional[Path] = None
+    folder: Union[PathLike, str, None] = None
     """The file specified above can optionally be relative to this folder."""
     format: Optional[FileFormat] = None
     """The format of the config file. If not specified, it will be inferred from the
@@ -73,7 +73,7 @@ class ConfZEnvSource(ConfZSource):
     remap: Optional[Dict[str, str]] = None
     """Certain environment variables can be mapped to config arguments with a different
     name."""
-    file: Optional[Path] = None
+    file: Union[Path, str, bytes, None] = None
     """Built in .env file loading with lower than environment precedence. Uses UTF-8
     for decoding."""
     nested_separator: str = "."

--- a/confz/loaders/env_loader.py
+++ b/confz/loaders/env_loader.py
@@ -1,4 +1,6 @@
+import io
 import os
+from pathlib import Path
 from typing import Dict, Optional, Any
 
 from dotenv import dotenv_values
@@ -49,7 +51,12 @@ class EnvLoader(Loader):
 
         origin_env_vars: Dict[str, Any] = dict(os.environ)
         if confz_source.file is not None:
-            origin_env_vars = {**dotenv_values(confz_source.file), **origin_env_vars}
+            if not isinstance(confz_source.file, bytes):
+                stream = Path(confz_source.file).open("r", encoding="utf-8")
+            else:
+                byte_stream = io.BytesIO(confz_source.file)
+                stream = io.TextIOWrapper(byte_stream, encoding="utf-8")
+            origin_env_vars = {**dotenv_values(None, stream), **origin_env_vars}
 
         env_vars = {}
         for env_var in origin_env_vars:

--- a/confz/loaders/file_loader.py
+++ b/confz/loaders/file_loader.py
@@ -118,8 +118,8 @@ class FileLoader(Loader):
                 "configuration is passed as byte-string"
             )
         byte_stream = io.BytesIO(data)
-        utf_reader = codecs.getreader(confz_source.encoding)
-        text_stream = utf_reader(byte_stream)
+        text_reader = codecs.getreader(confz_source.encoding)
+        text_stream = text_reader(byte_stream)
         file_content = cls._parse_stream(text_stream, confz_source.format)
         cls.update_dict_recursively(config, file_content)
 

--- a/confz/loaders/file_loader.py
+++ b/confz/loaders/file_loader.py
@@ -1,4 +1,3 @@
-import codecs
 import io
 import json
 import os
@@ -57,7 +56,7 @@ class FileLoader(Loader):
             raise ConfZFileException("No file source set.")
 
         if confz_source.folder is not None:
-            file_path = confz_source.folder / file_path
+            file_path = Path(confz_source.folder) / file_path
 
         return file_path
 
@@ -88,7 +87,7 @@ class FileLoader(Loader):
     @classmethod
     def _parse_stream(
         cls,
-        stream: Union[TextIO, codecs.StreamReader],
+        stream: Union[TextIO],
         file_format: FileFormat,
     ) -> dict:
         if file_format == FileFormat.YAML:
@@ -118,8 +117,7 @@ class FileLoader(Loader):
                 "configuration is passed as byte-string"
             )
         byte_stream = io.BytesIO(data)
-        text_reader = codecs.getreader(confz_source.encoding)
-        text_stream = text_reader(byte_stream)
+        text_stream = io.TextIOWrapper(byte_stream, encoding=confz_source.encoding)
         file_content = cls._parse_stream(text_stream, confz_source.format)
         cls.update_dict_recursively(config, file_content)
 

--- a/docs/source/usage/confz_class.rst
+++ b/docs/source/usage/confz_class.rst
@@ -74,7 +74,7 @@ We can load this file as follows:
 
 >>> from pathlib import Path
 >>> from confz import ConfZFileSource
->>> APIConfig(config_sources=ConfZFileSource(file=Path("/path/to/config.yaml")))
+>>> APIConfig(config_sources=ConfZFileSource(file="/path/to/config.yaml"))
 APIConfig(
     host=AnyUrl('http://my-host.com', scheme='http', host='my-host.com', tld='com', host_type='domain'),
     port=1234,
@@ -100,7 +100,7 @@ source as a class variable `CONFIG_SOURCES`:
 ...     port: int
 ...     db: DBConfig
 ...
-...     CONFIG_SOURCES = ConfZFileSource(file=Path('/path/to/config.yaml'))
+...     CONFIG_SOURCES = ConfZFileSource(file="/path/to/config.yaml")
 
 From now on, your config values are accessible from anywhere within your code by just importing ``APIConfig`` and
 instantiating it:

--- a/docs/source/usage/context_manager.rst
+++ b/docs/source/usage/context_manager.rst
@@ -11,7 +11,7 @@ In some scenarios, you might want to change your config values, for example with
 
 >>> class MyConfig(ConfZ):
 ...     number: int
-...     CONFIG_SOURCES = ConfZFileSource(file=Path("/path/to/config.yml"))
+...     CONFIG_SOURCES = ConfZFileSource(file="/path/to/config.yml")
 
 >>> print(MyConfig().number)
 1

--- a/tests/loaders/test_env_loader.py
+++ b/tests/loaders/test_env_loader.py
@@ -130,6 +130,17 @@ def test_dotenv_loading(monkeypatch):
     assert config.inner.attr_override == "2002"
 
 
+def test_dotenv_loading_from_bytes(monkeypatch):
+    monkeypatch.setenv("INNER.ATTR1_NAME", "21")
+    monkeypatch.setenv("ATTR2", "1")
+    with (ASSET_FOLDER / "config.env").open("rb") as config_file:
+        data = config_file.read()
+    config = OuterConfig(config_sources=ConfZEnvSource(allow_all=True, file=data))
+    assert config.attr2 == 1
+    assert config.inner.attr1_name == 21
+    assert config.inner.attr_override == "2002"
+
+
 def test_separator(monkeypatch):
     monkeypatch.setenv("INNER__ATTR1_NAME", "21")
     monkeypatch.setenv("INNER__ATTR-OVERRIDE", "2002")

--- a/tests/loaders/test_file_loader.py
+++ b/tests/loaders/test_file_loader.py
@@ -78,10 +78,24 @@ def test_toml_file():
     assert config.attrs[1].value == "2"
 
 
+def test_bytes_file():
+    json_dummy_content = b'{"inner":{"attr1": "2"}, "attr2": "5"}'
+    config = OuterConfig(
+        config_sources=ConfZFileSource(file=json_dummy_content,
+                                       format=FileFormat.JSON)
+    )
+    assert config.attr2 == "5"
+    assert config.inner.attr1 == "2"
+    with pytest.raises(ConfZFileException):
+        OuterConfig(
+            config_sources=ConfZFileSource(file=json_dummy_content))
+
+
 def test_custom_file():
     # does not recognize format per default
     with pytest.raises(ConfZFileException):
-        OuterConfig(config_sources=ConfZFileSource(file=ASSET_FOLDER / "config.txt"))
+        OuterConfig(
+            config_sources=ConfZFileSource(file=ASSET_FOLDER / "config.txt"))
 
     # can specify format
     config = OuterConfig(
@@ -93,10 +107,30 @@ def test_custom_file():
     assert config.attr2 == "2"
 
 
+def test_custom_file_str_path():
+    # can specify format
+    config = OuterConfig(
+        config_sources=ConfZFileSource(
+            file=str(ASSET_FOLDER)+ "/config.txt", format=FileFormat.YAML
+        )
+    )
+    assert config.inner.attr1 == "1 🎉"
+    assert config.attr2 == "2"
+
+
 def test_invalid_file():
     with pytest.raises(ConfZFileException):
         OuterConfig(
-            config_sources=ConfZFileSource(file=ASSET_FOLDER / "non_existing.json")
+            config_sources=ConfZFileSource(
+                file=ASSET_FOLDER / "non_existing.json")
+        )
+
+
+def test_invalid_file_str():
+    with pytest.raises(ConfZFileException):
+        OuterConfig(
+            config_sources=ConfZFileSource(
+                file=str(ASSET_FOLDER) + "/non_existing.json")
         )
 
 
@@ -117,7 +151,8 @@ def test_from_env(monkeypatch):
     # works if set
     monkeypatch.setenv(env_var, "config.json")
     config = OuterConfig(
-        config_sources=ConfZFileSource(file_from_env=env_var, folder=ASSET_FOLDER)
+        config_sources=ConfZFileSource(file_from_env=env_var,
+                                       folder=ASSET_FOLDER)
     )
     assert config.inner.attr1 == "1 🎉"
     assert config.attr2 == "2"
@@ -136,7 +171,8 @@ def test_from_cl_arg_idx(monkeypatch):
     # works if set
     monkeypatch.setattr(sys, "argv", argv_backup + ["config.json"])
     config = OuterConfig(
-        config_sources=ConfZFileSource(file_from_cl=cl_arg_idx, folder=ASSET_FOLDER)
+        config_sources=ConfZFileSource(file_from_cl=cl_arg_idx,
+                                       folder=ASSET_FOLDER)
     )
     assert config.inner.attr1 == "1 🎉"
     assert config.attr2 == "2"

--- a/tests/loaders/test_file_loader.py
+++ b/tests/loaders/test_file_loader.py
@@ -162,6 +162,19 @@ def test_from_env(monkeypatch):
     assert config.attr2 == "2"
 
 
+def test_from_env_using_str_path(monkeypatch):
+    env_var = "MY_CONFIG_FILE"
+
+    # works if set
+    monkeypatch.setenv(env_var, "config.json")
+    assert_folder_str: str = str(ASSET_FOLDER)
+    config = OuterConfig(
+        config_sources=ConfZFileSource(file_from_env=env_var, folder=assert_folder_str)
+    )
+    assert config.inner.attr1 == "1 🎉"
+    assert config.attr2 == "2"
+
+
 def test_from_cl_arg_idx(monkeypatch):
     argv_backup = sys.argv.copy()
     cl_arg_idx = len(argv_backup)

--- a/tests/loaders/test_file_loader.py
+++ b/tests/loaders/test_file_loader.py
@@ -5,6 +5,7 @@ import pytest
 
 from confz import ConfZ, ConfZFileSource, FileFormat
 from confz.exceptions import ConfZFileException
+from confz.loaders.file_loader import FileLoader
 from tests.assets import ASSET_FOLDER
 
 
@@ -81,21 +82,18 @@ def test_toml_file():
 def test_bytes_file():
     json_dummy_content = b'{"inner":{"attr1": "2"}, "attr2": "5"}'
     config = OuterConfig(
-        config_sources=ConfZFileSource(file=json_dummy_content,
-                                       format=FileFormat.JSON)
+        config_sources=ConfZFileSource(file=json_dummy_content, format=FileFormat.JSON)
     )
     assert config.attr2 == "5"
     assert config.inner.attr1 == "2"
     with pytest.raises(ConfZFileException):
-        OuterConfig(
-            config_sources=ConfZFileSource(file=json_dummy_content))
+        OuterConfig(config_sources=ConfZFileSource(file=json_dummy_content))
 
 
 def test_custom_file():
     # does not recognize format per default
     with pytest.raises(ConfZFileException):
-        OuterConfig(
-            config_sources=ConfZFileSource(file=ASSET_FOLDER / "config.txt"))
+        OuterConfig(config_sources=ConfZFileSource(file=ASSET_FOLDER / "config.txt"))
 
     # can specify format
     config = OuterConfig(
@@ -107,11 +105,18 @@ def test_custom_file():
     assert config.attr2 == "2"
 
 
+def test_file_path_from_bytes():
+    json_dummy_content = b'{"inner":{"attr1": "2"}, "attr2": "5"}'
+    source = ConfZFileSource(file=json_dummy_content, format=FileFormat.JSON)
+    with pytest.raises(ConfZFileException):
+        FileLoader._get_filename(source)
+
+
 def test_custom_file_str_path():
     # can specify format
     config = OuterConfig(
         config_sources=ConfZFileSource(
-            file=str(ASSET_FOLDER)+ "/config.txt", format=FileFormat.YAML
+            file=str(ASSET_FOLDER) + "/config.txt", format=FileFormat.YAML
         )
     )
     assert config.inner.attr1 == "1 🎉"
@@ -121,8 +126,7 @@ def test_custom_file_str_path():
 def test_invalid_file():
     with pytest.raises(ConfZFileException):
         OuterConfig(
-            config_sources=ConfZFileSource(
-                file=ASSET_FOLDER / "non_existing.json")
+            config_sources=ConfZFileSource(file=ASSET_FOLDER / "non_existing.json")
         )
 
 
@@ -130,7 +134,8 @@ def test_invalid_file_str():
     with pytest.raises(ConfZFileException):
         OuterConfig(
             config_sources=ConfZFileSource(
-                file=str(ASSET_FOLDER) + "/non_existing.json")
+                file=str(ASSET_FOLDER) + "/non_existing.json"
+            )
         )
 
 
@@ -151,8 +156,7 @@ def test_from_env(monkeypatch):
     # works if set
     monkeypatch.setenv(env_var, "config.json")
     config = OuterConfig(
-        config_sources=ConfZFileSource(file_from_env=env_var,
-                                       folder=ASSET_FOLDER)
+        config_sources=ConfZFileSource(file_from_env=env_var, folder=ASSET_FOLDER)
     )
     assert config.inner.attr1 == "1 🎉"
     assert config.attr2 == "2"
@@ -171,8 +175,7 @@ def test_from_cl_arg_idx(monkeypatch):
     # works if set
     monkeypatch.setattr(sys, "argv", argv_backup + ["config.json"])
     config = OuterConfig(
-        config_sources=ConfZFileSource(file_from_cl=cl_arg_idx,
-                                       folder=ASSET_FOLDER)
+        config_sources=ConfZFileSource(file_from_cl=cl_arg_idx, folder=ASSET_FOLDER)
     )
     assert config.inner.attr1 == "1 🎉"
     assert config.attr2 == "2"


### PR DESCRIPTION
The configuration source file (ConfZFileSource.file) can now - following the suggestions of PEP 519 - not just be defined by a Path anymore but also as `str` instead of a Path object or even directly as a `bytes`-string with the content of the configuration file.

If the content is provided as bytes string the definition of the format is mandatory as there is no file path anymore from which it could be derived.