### PR TITLE
Fix error when missing .env file

### DIFF
--- a/confz/loaders/env_loader.py
+++ b/confz/loaders/env_loader.py
@@ -53,7 +53,7 @@ class EnvLoader(Loader):
             if not isinstance(confz_source.file, bytes):
                 origin_env_vars = {
                     **dotenv_values(confz_source.file),
-                    **origin_env_vars
+                    **origin_env_vars,
                 }
             else:
                 byte_stream = io.BytesIO(confz_source.file)

--- a/confz/loaders/env_loader.py
+++ b/confz/loaders/env_loader.py
@@ -1,6 +1,5 @@
 import io
 import os
-from pathlib import Path
 from typing import Dict, Optional, Any
 
 from dotenv import dotenv_values
@@ -52,11 +51,11 @@ class EnvLoader(Loader):
         origin_env_vars: Dict[str, Any] = dict(os.environ)
         if confz_source.file is not None:
             if not isinstance(confz_source.file, bytes):
-                stream = Path(confz_source.file).open("r", encoding="utf-8")
+                origin_env_vars = {**dotenv_values(confz_source.file), **origin_env_vars}
             else:
                 byte_stream = io.BytesIO(confz_source.file)
                 stream = io.TextIOWrapper(byte_stream, encoding="utf-8")
-            origin_env_vars = {**dotenv_values(None, stream), **origin_env_vars}
+                origin_env_vars = {**dotenv_values(None, stream), **origin_env_vars}
 
         env_vars = {}
         for env_var in origin_env_vars:

--- a/confz/loaders/env_loader.py
+++ b/confz/loaders/env_loader.py
@@ -51,7 +51,10 @@ class EnvLoader(Loader):
         origin_env_vars: Dict[str, Any] = dict(os.environ)
         if confz_source.file is not None:
             if not isinstance(confz_source.file, bytes):
-                origin_env_vars = {**dotenv_values(confz_source.file), **origin_env_vars}
+                origin_env_vars = {
+                    **dotenv_values(confz_source.file),
+                    **origin_env_vars
+                }
             else:
                 byte_stream = io.BytesIO(confz_source.file)
                 stream = io.TextIOWrapper(byte_stream, encoding="utf-8")

--- a/tests/loaders/test_env_loader.py
+++ b/tests/loaders/test_env_loader.py
@@ -130,6 +130,17 @@ def test_dotenv_loading(monkeypatch):
     assert config.inner.attr_override == "2002"
 
 
+def test_dotenv_loading_missing_file(monkeypatch):
+    monkeypatch.setenv("INNER.ATTR1_NAME", "21")
+    monkeypatch.setenv("ATTR2", "1")
+    config = OuterConfig(
+        config_sources=ConfZEnvSource(allow_all=True, file=ASSET_FOLDER / "idontexist")
+    )
+    assert config.attr2 == 1
+    assert config.inner.attr1_name == 21
+    assert config.inner.attr_override is None
+
+
 def test_dotenv_loading_from_bytes(monkeypatch):
     monkeypatch.setenv("INNER.ATTR1_NAME", "21")
     monkeypatch.setenv("ATTR2", "1")


### PR DESCRIPTION
https://github.com/Zuehlke/ConfZ/pull/62 broke backwards compatibility for having *.env files be optional, as well as compatibility with dotenv's [find_dotenv](https://github.com/theskumar/python-dotenv/blob/7dc2492805f6bfc314b4ba4380d5ee5ad499b6c1/src/dotenv/main.py#L264) capability for searching the folder hierarchy for .env files.

This change tweaks the stream feature to restore the previous behavior for file-based env file loaders and adds a test with a nonexistent file.